### PR TITLE
add boolean schema with validation and tests

### DIFF
--- a/src/core/boolean.ts
+++ b/src/core/boolean.ts
@@ -21,7 +21,7 @@ const validateType = (value: unknown): BooleanParseResult => {
   if (typeof value !== 'boolean') {
     return {
       success: false,
-      value: Boolean(value),
+      value: value as boolean, // Return the original value without coercion
       error: {
         code: BooleanErrorCode.TYPE,
         message: `${BooleanErrorMessages[BooleanErrorCode.TYPE]}, got ${typeof value}`,

--- a/src/core/boolean.ts
+++ b/src/core/boolean.ts
@@ -1,0 +1,51 @@
+/**
+ * Boolean schema implementation for qs-parser
+ * Provides methods for creating and validating boolean schemas
+ */
+import type { BooleanParseResult } from './common.js';
+import { BooleanErrorCode, BooleanErrorMessages } from './error.js';
+
+/**
+ * Boolean schema type
+ */
+type BooleanSchema = {
+  parse: (value: unknown) => BooleanParseResult;
+};
+
+/**
+ * Validate that a value is a boolean
+ * @param value - The value to validate
+ * @returns The validation result
+ */
+const validateType = (value: unknown): BooleanParseResult => {
+  if (typeof value !== 'boolean') {
+    return {
+      success: false,
+      value: Boolean(value),
+      error: {
+        code: BooleanErrorCode.TYPE,
+        message: `${BooleanErrorMessages[BooleanErrorCode.TYPE]}, got ${typeof value}`,
+      },
+    };
+  }
+  return { success: true, value };
+};
+
+/**
+ * Create a boolean schema
+ * @returns A new boolean schema
+ */
+const boolean = (): BooleanSchema => {
+  // Create the schema object
+  const schema: BooleanSchema = {
+    parse: (value: unknown): BooleanParseResult => {
+      // Validate that the value is a boolean
+      return validateType(value);
+    },
+  };
+
+  return schema;
+};
+
+// Export the boolean schema creator
+export default boolean;

--- a/src/core/boolean.ts
+++ b/src/core/boolean.ts
@@ -37,14 +37,12 @@ const validateType = (value: unknown): BooleanParseResult => {
  */
 const boolean = (): BooleanSchema => {
   // Create the schema object
-  const schema: BooleanSchema = {
+  return {
     parse: (value: unknown): BooleanParseResult => {
       // Validate that the value is a boolean
       return validateType(value);
     },
   };
-
-  return schema;
 };
 
 // Export the boolean schema creator

--- a/src/core/boolean.ts
+++ b/src/core/boolean.ts
@@ -7,21 +7,32 @@ import { BooleanErrorCode, BooleanErrorMessages } from './error.js';
 
 /**
  * Boolean schema type
+ * Defines the interface for boolean validation schemas
  */
-type BooleanSchema = {
+export type BooleanSchema = {
+  /**
+   * Parse and validate a value as a boolean
+   * @param value - The value to validate
+   * @returns A parse result containing:
+   *   - success: true if validation passed, false otherwise
+   *   - value: the original input value (preserved without coercion in error cases)
+   *   - error: validation error details if success is false
+   */
   parse: (value: unknown) => BooleanParseResult;
 };
 
 /**
  * Validate that a value is a boolean
  * @param value - The value to validate
- * @returns The validation result
+ * @returns The validation result with the original input value preserved in error cases.
+ *          Note: The type assertion (value as boolean) does not perform any transformation
+ *          at runtime; it only informs TypeScript about the expected type.
  */
 const validateType = (value: unknown): BooleanParseResult => {
   if (typeof value !== 'boolean') {
     return {
       success: false,
-      value: value as boolean, // Return the original value without coercion
+      value: value as boolean, // Original value preserved without coercion
       error: {
         code: BooleanErrorCode.TYPE,
         message: `${BooleanErrorMessages[BooleanErrorCode.TYPE]}, got ${typeof value}`,

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -21,3 +21,8 @@ export type StringParseResult = ParseResult<string>;
  * Type for number parse results
  */
 export type NumberParseResult = ParseResult<number>;
+
+/**
+ * Type for boolean parse results
+ */
+export type BooleanParseResult = ParseResult<boolean>;

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -3,6 +3,20 @@
  */
 
 /**
+ * Error codes for boolean validation
+ */
+export enum BooleanErrorCode {
+  TYPE = 'boolean.type',
+}
+
+/**
+ * Error messages for boolean validation
+ */
+export const BooleanErrorMessages = {
+  [BooleanErrorCode.TYPE]: 'Expected boolean',
+};
+
+/**
  * Error codes for string validation
  */
 export enum StringErrorCode {

--- a/src/core/number.ts
+++ b/src/core/number.ts
@@ -153,7 +153,7 @@ const validateType = (value: unknown): NumberParseResult => {
     }`;
     return {
       success: false,
-      value: typeof value === 'number' ? value : 0,
+      value: value as number, // Return the original value without coercion
       error: {
         code: NumberErrorCode.TYPE,
         message,

--- a/src/core/number.ts
+++ b/src/core/number.ts
@@ -29,8 +29,9 @@ type NumberConstraints = {
 
 /**
  * Number schema type
+ * Defines the interface for number validation schemas
  */
-type NumberSchema = {
+export type NumberSchema = {
   /**
    * Parse a value as a number
    * @param value - The value to parse
@@ -144,7 +145,9 @@ type NumberSchema = {
 /**
  * Validate that a value is a number
  * @param value - The value to validate
- * @returns The validation result
+ * @returns The validation result with the original input value preserved in error cases.
+ *          Note: The type assertion (value as number) does not perform any transformation
+ *          at runtime; it only informs TypeScript about the expected type.
  */
 const validateType = (value: unknown): NumberParseResult => {
   if (typeof value !== 'number' || Number.isNaN(value)) {
@@ -153,7 +156,7 @@ const validateType = (value: unknown): NumberParseResult => {
     }`;
     return {
       success: false,
-      value: value as number, // Return the original value without coercion
+      value: value as number, // Original value preserved without coercion
       error: {
         code: NumberErrorCode.TYPE,
         message,

--- a/src/core/string.ts
+++ b/src/core/string.ts
@@ -72,7 +72,7 @@ const validateType = (value: unknown): StringParseResult => {
   if (typeof value !== 'string') {
     return {
       success: false,
-      value: String(value),
+      value: value as string, // Return the original value without coercion
       error: {
         code: StringErrorCode.TYPE,
         message: `${StringErrorMessages[StringErrorCode.TYPE]}, got ${typeof value}`,

--- a/src/core/string.ts
+++ b/src/core/string.ts
@@ -36,8 +36,17 @@ type StringConstraints = {
 
 /**
  * String schema type
+ * Defines the interface for string validation schemas
  */
-type StringSchema = {
+export type StringSchema = {
+  /**
+   * Parse and validate a value as a string
+   * @param value - The value to validate
+   * @returns A parse result containing:
+   *   - success: true if validation passed, false otherwise
+   *   - value: the original input value (preserved without coercion in error cases)
+   *   - error: validation error details if success is false
+   */
   parse: (value: unknown) => StringParseResult;
   max: (length: number) => StringSchema;
   min: (length: number) => StringSchema;
@@ -66,13 +75,15 @@ type StringSchema = {
 /**
  * Validate that a value is a string
  * @param value - The value to validate
- * @returns The validation result
+ * @returns The validation result with the original input value preserved in error cases.
+ *          Note: The type assertion (value as string) does not perform any transformation
+ *          at runtime; it only informs TypeScript about the expected type.
  */
 const validateType = (value: unknown): StringParseResult => {
   if (typeof value !== 'string') {
     return {
       success: false,
-      value: value as string, // Return the original value without coercion
+      value: value as string, // Original value preserved without coercion
       error: {
         code: StringErrorCode.TYPE,
         message: `${StringErrorMessages[StringErrorCode.TYPE]}, got ${typeof value}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
+import boolean from './core/boolean.js';
 import number from './core/number.js';
 import string from './core/string.js';
 
 export const q = {
   string,
   number,
+  boolean,
 };

--- a/tests/boolean.test.ts
+++ b/tests/boolean.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { BooleanErrorCode, BooleanErrorMessages } from '../src/core/error.js';
+import { q } from '../src/index.js';
+
+describe('boolean schema', () => {
+  it('should validate booleans', () => {
+    const schema = q.boolean();
+
+    // Valid boolean (true)
+    const result1 = schema.parse(true);
+    expect(result1.success).toBe(true);
+    expect(result1.value).toBe(true);
+
+    // Valid boolean (false)
+    const result2 = schema.parse(false);
+    expect(result2.success).toBe(true);
+    expect(result2.value).toBe(false);
+
+    // Non-boolean value (string)
+    const result3 = schema.parse('true');
+    expect(result3.success).toBe(false);
+    expect(result3.error?.message).toContain(
+      BooleanErrorMessages[BooleanErrorCode.TYPE],
+    );
+    expect(result3.error?.code).toBe(BooleanErrorCode.TYPE);
+
+    // Non-boolean value (number)
+    const result4 = schema.parse(1);
+    expect(result4.success).toBe(false);
+    expect(result4.error?.message).toContain(
+      BooleanErrorMessages[BooleanErrorCode.TYPE],
+    );
+    expect(result4.error?.code).toBe(BooleanErrorCode.TYPE);
+
+    // Non-boolean value (object)
+    const result5 = schema.parse({});
+    expect(result5.success).toBe(false);
+    expect(result5.error?.message).toContain(
+      BooleanErrorMessages[BooleanErrorCode.TYPE],
+    );
+    expect(result5.error?.code).toBe(BooleanErrorCode.TYPE);
+
+    // Non-boolean value (null)
+    const result6 = schema.parse(null);
+    expect(result6.success).toBe(false);
+    expect(result6.error?.message).toContain(
+      BooleanErrorMessages[BooleanErrorCode.TYPE],
+    );
+    expect(result6.error?.code).toBe(BooleanErrorCode.TYPE);
+
+    // Non-boolean value (undefined)
+    const result7 = schema.parse(undefined);
+    expect(result7.success).toBe(false);
+    expect(result7.error?.message).toContain(
+      BooleanErrorMessages[BooleanErrorCode.TYPE],
+    );
+    expect(result7.error?.code).toBe(BooleanErrorCode.TYPE);
+  });
+});

--- a/tests/boolean.test.ts
+++ b/tests/boolean.test.ts
@@ -17,40 +17,50 @@ describe('boolean schema', () => {
     expect(result2.value).toBe(false);
 
     // Non-boolean value (string)
-    const result3 = schema.parse('true');
+    const stringValue = 'true';
+    const result3 = schema.parse(stringValue);
     expect(result3.success).toBe(false);
+    expect(result3.value).toBe(stringValue); // Original value is preserved
     expect(result3.error?.message).toContain(
       BooleanErrorMessages[BooleanErrorCode.TYPE],
     );
     expect(result3.error?.code).toBe(BooleanErrorCode.TYPE);
 
     // Non-boolean value (number)
-    const result4 = schema.parse(1);
+    const numberValue = 1;
+    const result4 = schema.parse(numberValue);
     expect(result4.success).toBe(false);
+    expect(result4.value).toBe(numberValue); // Original value is preserved
     expect(result4.error?.message).toContain(
       BooleanErrorMessages[BooleanErrorCode.TYPE],
     );
     expect(result4.error?.code).toBe(BooleanErrorCode.TYPE);
 
     // Non-boolean value (object)
-    const result5 = schema.parse({});
+    const objectValue = {};
+    const result5 = schema.parse(objectValue);
     expect(result5.success).toBe(false);
+    expect(result5.value).toBe(objectValue); // Original value is preserved
     expect(result5.error?.message).toContain(
       BooleanErrorMessages[BooleanErrorCode.TYPE],
     );
     expect(result5.error?.code).toBe(BooleanErrorCode.TYPE);
 
     // Non-boolean value (null)
-    const result6 = schema.parse(null);
+    const nullValue = null;
+    const result6 = schema.parse(nullValue);
     expect(result6.success).toBe(false);
+    expect(result6.value).toBe(nullValue); // Original value is preserved
     expect(result6.error?.message).toContain(
       BooleanErrorMessages[BooleanErrorCode.TYPE],
     );
     expect(result6.error?.code).toBe(BooleanErrorCode.TYPE);
 
     // Non-boolean value (undefined)
-    const result7 = schema.parse(undefined);
+    const undefinedValue = undefined;
+    const result7 = schema.parse(undefinedValue);
     expect(result7.success).toBe(false);
+    expect(result7.value).toBe(undefinedValue); // Original value is preserved
     expect(result7.error?.message).toContain(
       BooleanErrorMessages[BooleanErrorCode.TYPE],
     );

--- a/tests/number.test.ts
+++ b/tests/number.test.ts
@@ -13,16 +13,20 @@ describe('number schema', () => {
     expect(result1.value).toBe(123);
 
     // Non-number value
-    const result2 = schema.parse('123');
+    const stringValue = '123';
+    const result2 = schema.parse(stringValue);
     expect(result2.success).toBe(false);
+    expect(result2.value).toBe(stringValue); // Original value is preserved
     expect(result2.error?.message).toContain(
       NumberErrorMessages[NumberErrorCode.TYPE],
     );
     expect(result2.error?.code).toBe(NumberErrorCode.TYPE);
 
     // NaN value
-    const result3 = schema.parse(Number.NaN);
+    const nanValue = Number.NaN;
+    const result3 = schema.parse(nanValue);
     expect(result3.success).toBe(false);
+    expect(Number.isNaN(result3.value)).toBe(true); // Original NaN value is preserved
     expect(result3.error?.message).toContain(
       NumberErrorMessages[NumberErrorCode.TYPE],
     );

--- a/tests/string.test.ts
+++ b/tests/string.test.ts
@@ -13,8 +13,10 @@ describe('string schema', () => {
     expect(result1.value).toBe('hello');
 
     // Non-string value
-    const result2 = schema.parse(123);
+    const numberValue = 123;
+    const result2 = schema.parse(numberValue);
     expect(result2.success).toBe(false);
+    expect(result2.value).toBe(numberValue); // Original value is preserved
     expect(result2.error?.message).toContain(
       StringErrorMessages[StringErrorCode.TYPE],
     );


### PR DESCRIPTION
This pull request introduces a new `boolean` schema to the `qs-parser` library, enabling validation and parsing of boolean values. The implementation includes the schema definition, error handling, and comprehensive tests. Below are the most important changes:

### New Feature: Boolean Schema Implementation
* Added a `boolean` schema in `src/core/boolean.ts`, including methods for creating and validating boolean schemas. It uses a `validateType` function to ensure the input is a boolean and returns appropriate error messages for invalid types.
* Exported the `boolean` schema through the main library entry point in `src/index.ts`.

### Error Handling Enhancements
* Introduced `BooleanErrorCode` and `BooleanErrorMessages` in `src/core/error.ts` to define error codes and messages specific to boolean validation.

### Type Definitions
* Added `BooleanParseResult` type in `src/core/common.ts` to represent the result of parsing boolean values.

### Testing
* Created `tests/boolean.test.ts` to validate the functionality of the `boolean` schema. The tests cover valid boolean inputs (`true`, `false`) and invalid inputs such as strings, numbers, objects, `null`, and `undefined`.