### PR TITLE
refactor: standardize UUID validation method names to camelCase

### DIFF
--- a/src/core/string/schema.ts
+++ b/src/core/string/schema.ts
@@ -68,8 +68,8 @@ const string = (): StringSchema => {
           validators.validateUrl(stringValue, newConstraints.isUrl),
           validators.validateEmoji(stringValue, newConstraints.isEmoji),
           validators.validateUuid(stringValue, newConstraints.isUuid),
-          validators.validateUuidv4(stringValue, newConstraints.isUuidv4),
-          validators.validateUuidv7(stringValue, newConstraints.isUuidv7),
+          validators.validateUuidV4(stringValue, newConstraints.isUuidV4),
+          validators.validateUuidV7(stringValue, newConstraints.isUuidV7),
           validators.validateCuid(stringValue, newConstraints.isCuid),
           validators.validateCuid2(stringValue, newConstraints.isCuid2),
           validators.validateUlid(stringValue, newConstraints.isUlid),
@@ -172,21 +172,21 @@ const string = (): StringSchema => {
         );
       },
 
-      uuidv4: (): StringSchema => {
+      uuidV4: (): StringSchema => {
         return createSchemaWithConstraints(
           {
             ...newConstraints,
-            isUuidv4: true,
+            isUuidV4: true,
           },
           createStringSchema,
         );
       },
 
-      uuidv7: (): StringSchema => {
+      uuidV7: (): StringSchema => {
         return createSchemaWithConstraints(
           {
             ...newConstraints,
-            isUuidv7: true,
+            isUuidV7: true,
           },
           createStringSchema,
         );

--- a/src/core/string/types.ts
+++ b/src/core/string/types.ts
@@ -15,8 +15,8 @@ export type StringConstraints = {
   isUrl?: boolean;
   isEmoji?: boolean;
   isUuid?: boolean;
-  isUuidv4?: boolean;
-  isUuidv7?: boolean;
+  isUuidV4?: boolean;
+  isUuidV7?: boolean;
   isCuid?: boolean;
   isCuid2?: boolean;
   isUlid?: boolean;
@@ -83,8 +83,8 @@ export type StringSchema = {
   url: () => StringSchema;
   emoji: () => StringSchema;
   uuid: () => StringSchema;
-  uuidv4: () => StringSchema;
-  uuidv7: () => StringSchema;
+  uuidV4: () => StringSchema;
+  uuidV7: () => StringSchema;
   cuid: () => StringSchema;
   cuid2: () => StringSchema;
   ulid: () => StringSchema;

--- a/src/core/string/validators.ts
+++ b/src/core/string/validators.ts
@@ -213,15 +213,15 @@ export const validateUuid = (
 /**
  * Validate UUID v4 constraint
  * @param value - The string to validate
- * @param isUuidv4 - Whether to validate as UUID v4
+ * @param isUuidV4 - Whether to validate as UUID v4
  * @returns The validation result
  */
-export const validateUuidv4 = (
+export const validateUuidV4 = (
   value: string,
-  isUuidv4?: boolean,
+  isUuidV4?: boolean,
 ): StringParseResult => {
   if (
-    isUuidv4 &&
+    isUuidV4 &&
     !/^[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/i.test(
       value,
     )
@@ -241,15 +241,15 @@ export const validateUuidv4 = (
 /**
  * Validate UUID v7 constraint
  * @param value - The string to validate
- * @param isUuidv7 - Whether to validate as UUID v7
+ * @param isUuidV7 - Whether to validate as UUID v7
  * @returns The validation result
  */
-export const validateUuidv7 = (
+export const validateUuidV7 = (
   value: string,
-  isUuidv7?: boolean,
+  isUuidV7?: boolean,
 ): StringParseResult => {
   if (
-    isUuidv7 &&
+    isUuidV7 &&
     !/^[\da-f]{8}-[\da-f]{4}-7[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/i.test(
       value,
     )

--- a/tests/string.test.ts
+++ b/tests/string.test.ts
@@ -139,7 +139,7 @@ describe('string schema', () => {
   });
 
   it('should validate uuid v4', () => {
-    const schema = q.string().uuidv4();
+    const schema = q.string().uuidV4();
 
     // Valid UUIDv4
     const result1 = schema.parse('123e4567-e89b-42d3-a456-426614174000');
@@ -163,7 +163,7 @@ describe('string schema', () => {
   });
 
   it('should validate uuid v7', () => {
-    const schema = q.string().uuidv7();
+    const schema = q.string().uuidV7();
 
     // Valid UUIDv7
     const result1 = schema.parse('123e4567-e89b-72d3-a456-426614174000');


### PR DESCRIPTION
This pull request standardizes the naming convention for UUID-related methods, constraints, and validators across the codebase by updating all instances to use camel case (e.g., `uuidV4` and `uuidV7`). Additionally, it updates corresponding test cases to reflect these changes.

### Naming Convention Updates:

* [`src/core/string/schema.ts`](diffhunk://#diff-9075e03ce0e8014e8c366e329faea773f37814015ce96efebe89d772ee2600beL71-R72): Updated method names from `uuidv4` and `uuidv7` to `uuidV4` and `uuidV7` in the `StringSchema` definition. Adjusted the associated constraints to `isUuidV4` and `isUuidV7`. [[1]](diffhunk://#diff-9075e03ce0e8014e8c366e329faea773f37814015ce96efebe89d772ee2600beL71-R72) [[2]](diffhunk://#diff-9075e03ce0e8014e8c366e329faea773f37814015ce96efebe89d772ee2600beL175-R189)
* [`src/core/string/types.ts`](diffhunk://#diff-fdbd51d38e45b2a2c21ca372adaa4ec7ed69b880ae5d6ef4b4ae59606d5205bdL18-R19): Renamed `StringConstraints` and `StringSchema` properties from `isUuidv4`/`isUuidv7` to `isUuidV4`/`isUuidV7`, and updated their corresponding method definitions. [[1]](diffhunk://#diff-fdbd51d38e45b2a2c21ca372adaa4ec7ed69b880ae5d6ef4b4ae59606d5205bdL18-R19) [[2]](diffhunk://#diff-fdbd51d38e45b2a2c21ca372adaa4ec7ed69b880ae5d6ef4b4ae59606d5205bdL86-R87)
* [`src/core/string/validators.ts`](diffhunk://#diff-070f22b65abb95feebb3cbcc8fffdfd401aca45a54cf261cadd52051b120bd54L216-R224): Renamed validator functions and parameters from `validateUuidv4`/`validateUuidv7` to `validateUuidV4`/`validateUuidV7` to align with the new naming convention. [[1]](diffhunk://#diff-070f22b65abb95feebb3cbcc8fffdfd401aca45a54cf261cadd52051b120bd54L216-R224) [[2]](diffhunk://#diff-070f22b65abb95feebb3cbcc8fffdfd401aca45a54cf261cadd52051b120bd54L244-R252)

### Test Case Updates:

* [`tests/string.test.ts`](diffhunk://#diff-750ff12927c640a2c4f1e96d497dc9b5895d806c5ebca88edd266d3a8d20367bL142-R142): Updated test cases to use the new method names `uuidV4` and `uuidV7` in the string schema tests. [[1]](diffhunk://#diff-750ff12927c640a2c4f1e96d497dc9b5895d806c5ebca88edd266d3a8d20367bL142-R142) [[2]](diffhunk://#diff-750ff12927c640a2c4f1e96d497dc9b5895d806c5ebca88edd266d3a8d20367bL166-R166)