### PR TITLE
feat: implement object schema validation with optional, nullable, and…

### DIFF
--- a/src/core/common/types.ts
+++ b/src/core/common/types.ts
@@ -31,3 +31,8 @@ export type BooleanParseResult = ParseResult<boolean>;
  * Type for date parse results
  */
 export type DateParseResult = ParseResult<Date>;
+
+/**
+ * Type for object parse results
+ */
+export type ObjectParseResult = ParseResult<Record<string, unknown>>;

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -54,8 +54,8 @@ export enum StringErrorCode {
   URL = 'string.url',
   EMOJI = 'string.emoji',
   UUID = 'string.uuid',
-  UUID_V4 = 'string.uuidv4',
-  UUID_V7 = 'string.uuidv7',
+  UUID_V4 = 'string.uuidV4',
+  UUID_V7 = 'string.uuidV7',
   CUID = 'string.cuid',
   CUID2 = 'string.cuid2',
   ULID = 'string.ulid',
@@ -150,6 +150,24 @@ export const NumberErrorMessages = {
 export type ValidationError = {
   code: string;
   message: string;
+};
+
+/**
+ * Error codes for object validation
+ */
+export enum ObjectErrorCode {
+  TYPE = 'object.type',
+  REQUIRED = 'object.required',
+  UNKNOWN_KEYS = 'object.unknownKeys',
+}
+
+/**
+ * Error messages for object validation
+ */
+export const ObjectErrorMessages = {
+  [ObjectErrorCode.TYPE]: 'Expected object',
+  [ObjectErrorCode.REQUIRED]: 'Required key "{0}" is missing',
+  [ObjectErrorCode.UNKNOWN_KEYS]: 'Unknown key(s): {0}',
 };
 
 /**

--- a/src/core/object/index.ts
+++ b/src/core/object/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Object schema module for qs-parser
+ * Exports the object schema creator
+ */
+import object from './schema.js';
+
+export default object;

--- a/src/core/object/schema.ts
+++ b/src/core/object/schema.ts
@@ -1,0 +1,68 @@
+/**
+ * Object schema implementation for qs-parser
+ */
+import type { ObjectParseResult } from '../common/index.js';
+import {
+  defaultValue as makeDefault,
+  nullable as makeNullable,
+  optional as makeOptional,
+} from '../common/schema.js';
+import type {
+  ObjectSchema,
+  ObjectSchemaCreator,
+  ShapeDefinition,
+} from './types.js';
+import * as validators from './validators.js';
+
+/**
+ * Create an object schema
+ * @param shape - Optional shape definition for the object
+ * @returns A new object schema
+ */
+const object = (shape?: Record<string, unknown>): ObjectSchema => {
+  // Create the schema object with the common methods
+  return {
+    // Internal state that will be properly copied to new instances
+    _shapeDefinition: shape || (null as ShapeDefinition | null),
+    _isStrict: false,
+
+    optional: function () {
+      return makeOptional(this);
+    },
+
+    nullable: function () {
+      return makeNullable(this);
+    },
+
+    default: function (defaultValue: Record<string, unknown>) {
+      return makeDefault(this, defaultValue);
+    },
+
+    strict: function () {
+      const newSchema = Object.create(this);
+      newSchema._isStrict = true;
+      return newSchema;
+    },
+
+    parse: function (value: unknown): ObjectParseResult {
+      // Validate that the value is an object
+      const typeResult = validators.validateType(value);
+      if (!typeResult.success) {
+        return typeResult;
+      }
+
+      // If a shape is defined, validate against it
+      if (this._shapeDefinition) {
+        return validators.validateShape(
+          typeResult.value,
+          this._shapeDefinition,
+          this._isStrict,
+        );
+      }
+
+      return typeResult;
+    },
+  };
+};
+
+export default object as ObjectSchemaCreator;

--- a/src/core/object/schema.ts
+++ b/src/core/object/schema.ts
@@ -39,7 +39,12 @@ const object = (shape?: Record<string, unknown>): ObjectSchema => {
     },
 
     strict: function () {
-      const newSchema = Object.create(this);
+      const newSchema = {
+        ...this,
+        _shapeDefinition: this._shapeDefinition
+          ? { ...this._shapeDefinition }
+          : null,
+      };
       newSchema._isStrict = true;
       return newSchema;
     },

--- a/src/core/object/types.ts
+++ b/src/core/object/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Type definitions for object schema
+ */
+import type { ObjectParseResult } from '../common/index.js';
+
+/**
+ * Function to create an object schema
+ * @param shape - Optional shape definition for the object
+ * @returns A new object schema
+ */
+export type ObjectSchemaCreator = {
+  (): ObjectSchema;
+  (shape: Record<string, unknown>): ObjectSchema;
+};
+
+/**
+ * Object schema type
+ * Defines the interface for object validation schemas
+ */
+export type ObjectSchema = {
+  /**
+   * Internal shape definition for the object
+   * @internal
+   */
+  _shapeDefinition: ShapeDefinition | null;
+
+  /**
+   * Internal flag for strict mode
+   * @internal
+   */
+  _isStrict: boolean;
+
+  /**
+   * Makes the schema accept undefined values
+   * @returns A new schema that accepts undefined values
+   */
+  optional: () => ObjectSchema & {
+    parse: (
+      value: unknown,
+    ) => ObjectParseResult | { success: true; value: undefined };
+  };
+
+  /**
+   * Makes the schema accept null values
+   * @returns A new schema that accepts null values
+   */
+  nullable: () => ObjectSchema & {
+    parse: (
+      value: unknown,
+    ) => ObjectParseResult | { success: true; value: null };
+  };
+
+  /**
+   * Sets a default value for the schema when the input is undefined
+   * @param defaultValue - The default value to use when the input is undefined
+   * @returns A new schema
+   * that uses the default value when the input is undefined
+   */
+  default: (defaultValue: Record<string, unknown>) => ObjectSchema;
+
+  /**
+   * Specifies that the object should not contain any keys not defined in the shape
+   * @returns A new schema that rejects objects with unknown keys
+   */
+  strict: () => ObjectSchema;
+
+  /**
+   * Parse and validate a value as an object
+   * @param value - The value to validate
+   * @returns A parse result containing:
+   *   - success: true if validation passed, false otherwise
+   *   - value: the original input value (preserved without coercion in error cases)
+   *   - error: validation error details if success is false
+   */
+  parse: (value: unknown) => ObjectParseResult;
+};
+
+/**
+ * Shape definition for object schemas
+ */
+export type ShapeDefinition = Record<string, unknown>;

--- a/src/core/object/validators.ts
+++ b/src/core/object/validators.ts
@@ -1,0 +1,86 @@
+/**
+ * Validation functions for object schema
+ */
+import type { ObjectParseResult } from '../common/index.js';
+import { ObjectErrorCode, ObjectErrorMessages } from '../error.js';
+import type { ShapeDefinition } from './types.js';
+
+/**
+ * Get a string representation of a value's type
+ * @param value - The value to get the type of
+ * @returns A string representation of the value's type
+ */
+const getValueType = (value: unknown): string => {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+};
+
+/**
+ * Validate that a value is an object
+ * @param value - The value to validate
+ * @returns The validation result with the original input value preserved in error cases.
+ */
+export const validateType = (value: unknown): ObjectParseResult => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return {
+      success: false,
+      value: value as Record<string, unknown>,
+      error: {
+        code: ObjectErrorCode.TYPE,
+        message: `${ObjectErrorMessages[ObjectErrorCode.TYPE]}, got ${getValueType(value)}`,
+      },
+    };
+  }
+  return { success: true, value: value as Record<string, unknown> };
+};
+
+/**
+ * Validate that an object matches a shape definition
+ * @param value - The object to validate
+ * @param shape - The shape definition to validate against
+ * @param strict - Whether to reject unknown keys
+ * @returns The validation result
+ */
+export const validateShape = (
+  value: Record<string, unknown>,
+  shape: ShapeDefinition,
+  strict = false,
+): ObjectParseResult => {
+  // Check for required keys
+  for (const key in shape) {
+    if (!(key in value)) {
+      return {
+        success: false,
+        value,
+        error: {
+          code: ObjectErrorCode.REQUIRED,
+          message: ObjectErrorMessages[ObjectErrorCode.REQUIRED].replace(
+            '{0}',
+            key,
+          ),
+        },
+      };
+    }
+  }
+
+  // Check for unknown keys if strict mode is enabled
+  if (strict) {
+    const unknownKeys = Object.keys(value).filter((key) => !(key in shape));
+    if (unknownKeys.length > 0) {
+      return {
+        success: false,
+        value,
+        error: {
+          code: ObjectErrorCode.UNKNOWN_KEYS,
+          message: ObjectErrorMessages[ObjectErrorCode.UNKNOWN_KEYS].replace(
+            '{0}',
+            unknownKeys.join(', '),
+          ),
+        },
+      };
+    }
+  }
+
+  return { success: true, value };
+};

--- a/src/core/object/validators.ts
+++ b/src/core/object/validators.ts
@@ -48,7 +48,7 @@ export const validateShape = (
   strict = false,
 ): ObjectParseResult => {
   // Check for required keys
-  for (const key in shape) {
+  for (const key of Object.keys(shape)) {
     if (!(key in value)) {
       return {
         success: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import boolean from './core/boolean/index.js';
 import date from './core/date/index.js';
 import number from './core/number/index.js';
+import object from './core/object/index.js';
 import string from './core/string/index.js';
 
 export const q = {
@@ -8,4 +9,5 @@ export const q = {
   number,
   boolean,
   date,
+  object,
 };

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest';
+import { ObjectErrorCode, ObjectErrorMessages } from '../src/core/error.js';
+import { q } from '../src/index.js';
+import { formatMessage } from './helper.js';
+
+describe('object schema', () => {
+  it('should validate objects', () => {
+    const schema = q.object();
+
+    // Valid object (empty)
+    const result1 = schema.parse({});
+    expect(result1.success).toBe(true);
+    expect(result1.value).toEqual({});
+
+    // Valid object (with properties)
+    const objectValue = { name: 'John', age: 30 };
+    const result2 = schema.parse(objectValue);
+    expect(result2.success).toBe(true);
+    expect(result2.value).toEqual(objectValue);
+
+    // Non-object value (string)
+    const stringValue = 'not an object';
+    const result3 = schema.parse(stringValue);
+    expect(result3.success).toBe(false);
+    expect(result3.value).toBe(stringValue); // Original value is preserved
+    expect(result3.error?.message).toContain(
+      ObjectErrorMessages[ObjectErrorCode.TYPE],
+    );
+    expect(result3.error?.code).toBe(ObjectErrorCode.TYPE);
+
+    // Non-object value (number)
+    const numberValue = 123;
+    const result4 = schema.parse(numberValue);
+    expect(result4.success).toBe(false);
+    expect(result4.value).toBe(numberValue); // Original value is preserved
+    expect(result4.error?.message).toContain(
+      ObjectErrorMessages[ObjectErrorCode.TYPE],
+    );
+    expect(result4.error?.code).toBe(ObjectErrorCode.TYPE);
+
+    // Non-object value (boolean)
+    const booleanValue = true;
+    const result5 = schema.parse(booleanValue);
+    expect(result5.success).toBe(false);
+    expect(result5.value).toBe(booleanValue); // Original value is preserved
+    expect(result5.error?.message).toContain(
+      ObjectErrorMessages[ObjectErrorCode.TYPE],
+    );
+    expect(result5.error?.code).toBe(ObjectErrorCode.TYPE);
+
+    // Non-object value (null)
+    const nullValue = null;
+    const result6 = schema.parse(nullValue);
+    expect(result6.success).toBe(false);
+    expect(result6.value).toBe(nullValue); // Original value is preserved
+    expect(result6.error?.message).toContain(
+      ObjectErrorMessages[ObjectErrorCode.TYPE],
+    );
+    expect(result6.error?.code).toBe(ObjectErrorCode.TYPE);
+
+    // Non-object value (array)
+    const arrayValue = [1, 2, 3];
+    const result7 = schema.parse(arrayValue);
+    expect(result7.success).toBe(false);
+    expect(result7.value).toBe(arrayValue); // Original value is preserved
+    expect(result7.error?.message).toContain(
+      ObjectErrorMessages[ObjectErrorCode.TYPE],
+    );
+    expect(result7.error?.code).toBe(ObjectErrorCode.TYPE);
+
+    // Non-object value (undefined)
+    const undefinedValue = undefined;
+    const result8 = schema.parse(undefinedValue);
+    expect(result8.success).toBe(false);
+    expect(result8.value).toBe(undefinedValue); // Original value is preserved
+    expect(result8.error?.message).toContain(
+      ObjectErrorMessages[ObjectErrorCode.TYPE],
+    );
+    expect(result8.error?.code).toBe(ObjectErrorCode.TYPE);
+  });
+
+  it('should validate object shape', () => {
+    // Create a schema with a shape
+    const shape = {
+      name: q.string(),
+      age: q.number(),
+    };
+    const schema = q.object(shape);
+
+    // Valid object (matching shape)
+    const validObject = { name: 'John', age: 30 };
+    const result1 = schema.parse(validObject);
+    expect(result1.success).toBe(true);
+    expect(result1.value).toEqual(validObject);
+
+    // Invalid object (missing required property)
+    const missingProperty = { name: 'John' };
+    const result2 = schema.parse(missingProperty);
+    expect(result2.success).toBe(false);
+    expect(result2.value).toEqual(missingProperty);
+    expect(result2.error?.code).toBe(ObjectErrorCode.REQUIRED);
+    expect(result2.error?.message).toContain(
+      formatMessage(ObjectErrorMessages[ObjectErrorCode.REQUIRED], 'age'),
+    );
+
+    // Valid object (extra properties allowed by default)
+    const extraProperties = {
+      name: 'John',
+      age: 30,
+      email: 'john@example.com',
+    };
+    const result3 = schema.parse(extraProperties);
+    expect(result3.success).toBe(true);
+    expect(result3.value).toEqual(extraProperties);
+  });
+
+  it('should validate strict mode', () => {
+    // Create a schema with a shape and strict mode
+    const shape = {
+      name: q.string(),
+      age: q.number(),
+    };
+    const schema = q.object(shape).strict();
+
+    // Valid object (matching shape exactly)
+    const validObject = { name: 'John', age: 30 };
+    const result1 = schema.parse(validObject);
+    expect(result1.success).toBe(true);
+    expect(result1.value).toEqual(validObject);
+
+    // Invalid object (extra properties not allowed in strict mode)
+    const extraProperties = {
+      name: 'John',
+      age: 30,
+      email: 'john@example.com',
+    };
+    const result2 = schema.parse(extraProperties);
+    expect(result2.success).toBe(false);
+    expect(result2.value).toEqual(extraProperties);
+    expect(result2.error?.code).toBe(ObjectErrorCode.UNKNOWN_KEYS);
+    expect(result2.error?.message).toContain(
+      formatMessage(ObjectErrorMessages[ObjectErrorCode.UNKNOWN_KEYS], 'email'),
+    );
+  });
+
+  it('should validate q.object(shape).strict() with nested objects and multiple unknown keys', () => {
+    // Create a schema with nested shapes and strict mode
+    const addressShape = {
+      street: q.string(),
+      city: q.string(),
+      zipCode: q.string(),
+    };
+
+    const userShape = {
+      name: q.string(),
+      age: q.number(),
+      address: q.object(addressShape),
+    };
+
+    const schema = q.object(userShape).strict();
+
+    // Valid object (matching shape exactly)
+    const validObject = {
+      name: 'John',
+      age: 30,
+      address: {
+        street: '123 Main St',
+        city: 'New York',
+        zipCode: '10001',
+      },
+    };
+    const result1 = schema.parse(validObject);
+    expect(result1.success).toBe(true);
+    expect(result1.value).toEqual(validObject);
+
+    // Invalid object (multiple extra properties not allowed in strict mode)
+    const extraProperties = {
+      name: 'John',
+      age: 30,
+      email: 'john@example.com',
+      phone: '123-456-7890',
+      address: {
+        street: '123 Main St',
+        city: 'New York',
+        zipCode: '10001',
+      },
+    };
+    const result2 = schema.parse(extraProperties);
+    expect(result2.success).toBe(false);
+    expect(result2.value).toEqual(extraProperties);
+    expect(result2.error?.code).toBe(ObjectErrorCode.UNKNOWN_KEYS);
+    // Should contain both unknown keys in the error message
+    expect(result2.error?.message).toContain('email');
+    expect(result2.error?.message).toContain('phone');
+
+    // Test with non-strict nested object inside strict parent
+    const mixedSchema = q
+      .object({
+        name: q.string(),
+        profile: q.object({
+          bio: q.string(),
+          skills: q.string(),
+        }), // non-strict nested object
+      })
+      .strict(); // strict parent
+
+    const validMixedObject = {
+      name: 'John',
+      profile: {
+        bio: 'Developer',
+        skills: 'JavaScript, TypeScript',
+        // Extra property in non-strict nested object should be allowed
+        experience: '5 years',
+      },
+    };
+
+    const result3 = mixedSchema.parse(validMixedObject);
+    expect(result3.success).toBe(true);
+    expect(result3.value).toEqual(validMixedObject);
+
+    // But extra properties at the top level should still be rejected
+    const invalidMixedObject = {
+      name: 'John',
+      profile: {
+        bio: 'Developer',
+        skills: 'JavaScript, TypeScript',
+      },
+      extraTopLevel: true,
+    };
+
+    const result4 = mixedSchema.parse(invalidMixedObject);
+    expect(result4.success).toBe(false);
+    expect(result4.error?.code).toBe(ObjectErrorCode.UNKNOWN_KEYS);
+    expect(result4.error?.message).toContain('extraTopLevel');
+  });
+
+  it('should support optional objects', () => {
+    const schema = q.object().optional();
+
+    // Valid object
+    const validObject = { name: 'John' };
+    const result1 = schema.parse(validObject);
+    expect(result1.success).toBe(true);
+    expect(result1.value).toEqual(validObject);
+
+    // Undefined value (allowed with optional)
+    const result2 = schema.parse(undefined);
+    expect(result2.success).toBe(true);
+    expect(result2.value).toBe(undefined);
+
+    // Null value (not allowed with optional)
+    const result3 = schema.parse(null);
+    expect(result3.success).toBe(false);
+    expect(result3.error?.code).toBe(ObjectErrorCode.TYPE);
+  });
+
+  it('should support nullable objects', () => {
+    const schema = q.object().nullable();
+
+    // Valid object
+    const validObject = { name: 'John' };
+    const result1 = schema.parse(validObject);
+    expect(result1.success).toBe(true);
+    expect(result1.value).toEqual(validObject);
+
+    // Null value (allowed with nullable)
+    const result2 = schema.parse(null);
+    expect(result2.success).toBe(true);
+    expect(result2.value).toBe(null);
+
+    // Undefined value (not allowed with nullable)
+    const result3 = schema.parse(undefined);
+    expect(result3.success).toBe(false);
+    expect(result3.error?.code).toBe(ObjectErrorCode.TYPE);
+  });
+
+  it('should support default values', () => {
+    const defaultValue = { name: 'Default', age: 0 };
+    const schema = q.object().default(defaultValue);
+
+    // Valid object
+    const validObject = { name: 'John', age: 30 };
+    const result1 = schema.parse(validObject);
+    expect(result1.success).toBe(true);
+    expect(result1.value).toEqual(validObject);
+
+    // Undefined value (uses default)
+    const result2 = schema.parse(undefined);
+    expect(result2.success).toBe(true);
+    expect(result2.value).toEqual(defaultValue);
+
+    // Null value (not allowed with default)
+    const result3 = schema.parse(null);
+    expect(result3.success).toBe(false);
+    expect(result3.error?.code).toBe(ObjectErrorCode.TYPE);
+  });
+
+  it('should support chaining methods', () => {
+    const defaultValue = { name: 'Default', age: 0 };
+    const shape = {
+      name: q.string(),
+      age: q.number(),
+    };
+
+    // Chain multiple methods
+    const schema = q.object(shape).nullable().default(defaultValue);
+
+    // Valid object
+    const validObject = { name: 'John', age: 30 };
+    const result1 = schema.parse(validObject);
+    expect(result1.success).toBe(true);
+    expect(result1.value).toEqual(validObject);
+
+    // Null value (allowed with nullable)
+    const result2 = schema.parse(null);
+    expect(result2.success).toBe(true);
+    expect(result2.value).toBe(null);
+
+    // Undefined value (uses default)
+    const result3 = schema.parse(undefined);
+    expect(result3.success).toBe(true);
+    expect(result3.value).toEqual(defaultValue);
+
+    // Invalid object (missing required property)
+    const missingProperty = { name: 'John' };
+    const result4 = schema.parse(missingProperty);
+    expect(result4.success).toBe(false);
+    expect(result4.error?.code).toBe(ObjectErrorCode.REQUIRED);
+  });
+});


### PR DESCRIPTION
… default value support
This pull request introduces a new object schema module for the `qs-parser` library, enabling object validation with features such as shape definitions, strict mode, and method chaining. It also includes extensive tests to ensure the functionality of the new features. Additionally, minor consistency improvements were made to existing code.

### New Object Schema Module
* Added a new `object` schema module with methods for validation, optional/nullable handling, default values, and strict mode. (`src/core/object/schema.ts`, `src/core/object/types.ts`, `src/core/object/validators.ts`, `src/core/object/index.ts`) [[1]](diffhunk://#diff-8515edde6a737b1a488eb5b2106ca7471cc83db05db83bc3531218fc664a42b0R1-R68) [[2]](diffhunk://#diff-7f1ce80b1c4a6d43d6bed8ccf6abf325ba1a0341cbc053701a1034dd81ecf5d8R1-R81) [[3]](diffhunk://#diff-44e914f11ab3f12db35d69973cf8cc03a029e26ae72c9da90e2468d818db87e0R1-R86) [[4]](diffhunk://#diff-f0629ea4f7c092fea01ac464d57df3703dd265b805f9a4255722872af142e97cR1-R7)
* Integrated the `object` schema into the main `q` export. (`src/index.ts`)

### Error Handling Enhancements
* Added `ObjectErrorCode` and `ObjectErrorMessages` for object-specific validation errors (e.g., type mismatch, missing required keys, unknown keys). (`src/core/error.ts`)
* Updated error code naming for consistency (e.g., `UUID_V4` to `UUID_V4`). (`src/core/error.ts`)

### Type Definitions
* Added `ObjectParseResult` and other type definitions to support the object schema module. (`src/core/common/types.ts`, `src/core/object/types.ts`) [[1]](diffhunk://#diff-699f0d2f769c0b6ba956b70a5a5dce20f9a3976ce5c8da0ba69b337f43f559e4R34-R38) [[2]](diffhunk://#diff-7f1ce80b1c4a6d43d6bed8ccf6abf325ba1a0341cbc053701a1034dd81ecf5d8R1-R81)

### Testing
* Added comprehensive tests for the `object` schema, covering validation, shape definitions, strict mode, optional/nullable handling, default values, and method chaining. (`tests/object.test.ts`)